### PR TITLE
disable omlpythonbridge build for now

### DIFF
--- a/src/oml/toolboxes/makefile.open
+++ b/src/oml/toolboxes/makefile.open
@@ -11,7 +11,7 @@ default:
 	make -C omlCAE          -f makefile.open
 	make -C plot            -f makefile.open
 	make -C omlMatio        -f makefile.open
-	make -C omlpythonbridge -f makefile.open
+#	make -C omlpythonbridge -f makefile.open
 	
 clean:
 	make -C omlMathUtils    clean -f makefile.open


### PR DESCRIPTION
Working to get Travis to build OpenMatrix repo, but the omlpythonbridge build is not working probably due to a python install problem on Travis.  I'd like to see if the rest of Travis can be enabled and working before switching to investigating the python version install.