### PR TITLE
try again to update the reference log

### DIFF
--- a/Tests/RegressionTests/RefLogs/rightMatDivFAIL6.log
+++ b/Tests/RegressionTests/RefLogs/rightMatDivFAIL6.log
@@ -1,1 +1,1 @@
-Error: incompatible dimensions at line number 1 in file rightMatDivFail6.oml
+Error: incompatible dimensions at line number 1 in file rightMatDivFAIL6.oml


### PR DESCRIPTION
This time I used the GPG signature on submitting this change.
My apologies at the repeated review request.
This change again updates the regression test log to match the updated script file name in the error message.

The update log contains the script name with all-caps FAIL.

bash-4.2 17:44:37 $ cat RefLogs/rightMatDiv**FAIL**6.log
Error: incompatible dimensions at line number 1 in file rightMatDiv**FAIL**6.oml