### PR TITLE
Add files require to use Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+install: true
+language: cpp
+addons:
+  apt_packages:
+    - gfortran
+sudo: required
+python: 
+- '3.6'
+before_install:
+- git clone --depth=50 --branch=master https://github.com/OpenMatrixLanguage/Continuous_Integration_Linux.git Linux
+env:
+  SH=bash
+  OML_ROOT=$PWD/OpenMatrixPublic
+  OML_THIRDPARTY=$PWD/Linux/third_party
+  LD_LIBRARY_PATH=$OML_THIRDPARTY/fftw/fftw-3.2.2/.libs:$LD_LIBRARY_PATH
+  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OML_THIRDPARTY/lapack/lapack-3.7.1
+  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OML_THIRDPARTY/ANTLR/libantlr3c-3.4/.libs
+  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OML_THIRDPARTY/matio/matio-1.5.11/src/.libs
+  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OML_THIRDPARTY/hdf5/hdf5-1.10.1/hdf5/lib
+  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OML_THIRDPARTY/sundials/sundials-3.1.0-install/lib
+  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OML_ROOT/src/bin/linux64
+  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/bin:/usr/lib
+  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu
+  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/lib/x86_64-linux-gnu
+  PATH=$PATH:$OML_ROOT/src/bin/linux64
+  OML_PYTHONHOME=/usr
+  OML_PYTHONVERSION=python3
+  OML_PYTHON_NUMPYDIR=$OML_PYTHONHOME/lib/$OML_PYTHONVERSION/dist-packages/numpy/core/include/numpy/
+before_script:
+script:
+- cd $OML_ROOT/src
+- ls -alF
+- make -f makefile.open
+after_success:
+#- chmod 777 $OML_ROOT/src/bin/linux64/omlconsole
+- ls -alF $OML_ROOT/src/bin/linux64
+- cd $OML_ROOT/Tests/RegressionTests && pwd
+- perl ../regressOMLConsole.pl -travis
+- cd $OML_ROOT/Tests && pwd
+- source run_toolbox_tests.sh
+- cd $OML_ROOT/Tests
+- source evaluate_test_results.sh
+compiler: gcc

--- a/Tests/evaluate_test_results.sh
+++ b/Tests/evaluate_test_results.sh
@@ -1,0 +1,55 @@
+eval_regression_test() {
+
+result=$(find $1 -maxdepth 1 -name '*.log' | wc -l)
+result_string=" - OK"
+
+if [ $result -gt 0 ]; then
+  test_result=1;
+  ls -alF $1/*.log
+  result_string=" - THIS TEST HAS FAILED"
+fi
+
+echo Test result fails for $1 are $result $result_string
+
+return $result
+}
+ 
+eval_toolbox_test() {
+
+result=$(find toolboxes/$1/tests -maxdepth 1 -name '*.log' | wc -l)
+result_string=" - OK"
+
+if [ $result -gt 0 ]; then
+  test_result=1;
+  ls -alF toolboxes/$1/tests/*.log
+  result_string=" - THIS TEST HAS FAILED"
+fi
+
+echo Test result fails for $1 are $result  $result_string
+
+return $result
+}
+
+# setup default test_result.  If no tests have failed, this will be the return result
+test_result=0
+
+#Check core regression tests for the existance of any *.log files
+eval_regression_test RegressionTests
+
+#Check each toolbox test directory for the existance of any *.log files
+eval_toolbox_test omlCAE
+eval_toolbox_test omlCalculus
+eval_toolbox_test omlDiffEq
+eval_toolbox_test omlMathUtils
+eval_toolbox_test omlMatio
+eval_toolbox_test omlOptimization
+eval_toolbox_test omlPolynom
+eval_toolbox_test omlpythonbridge
+eval_toolbox_test omlSignals
+eval_toolbox_test omlStatistics
+
+echo test_result $test_result
+if [ $test_result -ne 0 ]; then
+  echo Note:  Failed tests fails the build
+fi
+exit $test_result


### PR DESCRIPTION
The .travis.yml is the file Travis uses to run configure and run the build.
The script file evaluate_test_results.sh searches the test directories for log files.   Since the perl script deletes log files when they match the reference log, any left-over log files indicates a regression test failure.