### PR TITLE
test adding gcc 4.9.2 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 install: true
 language: cpp
 addons:
+  apt:
+   sources:
+    - ubuntu-toolchain-r-test
+   packages:
+    - g++-4.9
   apt_packages:
     - gfortran
 sudo: required
@@ -26,6 +31,7 @@ env:
   OML_PYTHONHOME=/usr
   OML_PYTHONVERSION=python3
   OML_PYTHON_NUMPYDIR=$OML_PYTHONHOME/lib/$OML_PYTHONVERSION/dist-packages/numpy/core/include/numpy/
+  MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 before_script:
 script:
 - cd $OML_ROOT/src


### PR DESCRIPTION
This is test to configure the Travis CI environment to use gcc 4.9.2