### PR TITLE
Update BuiltInFuncsSystem.cpp

### DIFF
--- a/src/oml/Runtime/BuiltInFuncsSystem.cpp
+++ b/src/oml/Runtime/BuiltInFuncsSystem.cpp
@@ -199,7 +199,7 @@ bool BuiltInFuncsSystem::Ls(EvaluatorInterface           eval,
     {
         char buf[256];
         memset(buf, 0, sizeof(buf));
-        if (fgets(buf, sizeof(buf), cmdoutput) <= 0)
+        if (!fgets(buf, sizeof(buf), cmdoutput))
         {
             std::cout << std::flush;
             break;
@@ -715,7 +715,7 @@ bool BuiltInFuncsSystem::System(EvaluatorInterface           eval,
 		while (1)
 		{
 			char buf[256];
-			if (fgets(buf, sizeof(buf), pipe) <= 0)
+			if (!fgets(buf, sizeof(buf), pipe))
 			{
 				break;
 			}


### PR DESCRIPTION
fixes this error:
```
BuiltInFuncsSystem.cpp: In static member function 'static bool BuiltInFuncsSystem::Ls(EvaluatorInterface, const std::vector<Currency>&, std::vector<Currency>&)':
BuiltInFuncsSystem.cpp:202:48: error: ordered comparison of pointer with integer zero ('char*' and 'int')
  202 |         if (fgets(buf, sizeof(buf), cmdoutput) <= 0)
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
BuiltInFuncsSystem.cpp: In static member function 'static bool BuiltInFuncsSystem::System(EvaluatorInterface, const std::vector<Currency>&, std::vector<Currency>&)':
BuiltInFuncsSystem.cpp:718:59: error: ordered comparison of pointer with integer zero ('char*' and 'int')
  718 |                         if (fgets(buf, sizeof(buf), pipe) <= 0)
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
make[1]: *** [makefile.open:45: linux64/BuiltInFuncsSystem.o] Error 1
make[1]: *** Waiting for unfinished jobs....
```